### PR TITLE
fix: wrong heading level at 16-bus.Rmd

### DIFF
--- a/16-bus.Rmd
+++ b/16-bus.Rmd
@@ -385,7 +385,7 @@ border_outer(fp_border()) %>%
 border_inner(fp_border())
 ```
 
-### 设备总线
+## 设备总线
 
 设备总线用于计算机系统中与IO设备的连接。
 


### PR DESCRIPTION
“设备总线”这个章节应该是二级章节（2 级标题），和“片上总线”、“内存总线”、“系统总线”并列，不应该是“系统总线”的子章节（3 级标题）。

目前错误的章节如图所示：

![image](https://github.com/user-attachments/assets/ed98929c-5bc2-478f-9f09-55a7b86ae81e)
